### PR TITLE
MEDIASERVICES-9354 v 1.4.3 sns_event can take either data or string m…

### DIFF
--- a/aws-lambda-runner.gemspec
+++ b/aws-lambda-runner.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'aws-lambda-runner'
-  s.version     = '1.4.2'
+  s.version     = '1.4.3'
   s.date        = '2015-07-31'
   s.summary     = 'AWS Lambda testing helper'
   s.description = 'Trigger AWS Lambda functions without deploying to AWS'

--- a/lib/lambda_runner.rb
+++ b/lib/lambda_runner.rb
@@ -84,6 +84,10 @@ module LambdaRunner
     end
 
     def self.sns_event(topicArn, messageId, timestamp, messageBody)
+      unless messageBody.kind_of? String
+        messageBody = JSON.generate messageBody
+      end
+
       event = load_json('sample_sns_event.json')
       event['Records'].each do |record|
         record['Sns']['TopicArn'] = topicArn

--- a/spec/lambda-runner_spec.rb
+++ b/spec/lambda-runner_spec.rb
@@ -11,12 +11,22 @@ describe LambdaRunner::Events do
     expect(data["Records"][0]["s3"]["object"]["key"]).to eq("some/key")
   end
 
-  it "should generate an SNS event" do
-    data = LambdaRunner::Events.sns_event("some-arn", "some-id", "some-timestamp", "some-body")
+  it "should generate an SNS event (data body)" do
+    message = { "this_is" => "the message" }
+    data = LambdaRunner::Events.sns_event("some-arn", "some-id", "some-timestamp", message)
     expect(data["Records"][0]["Sns"]["TopicArn"]).to eq("some-arn")
     expect(data["Records"][0]["Sns"]["MessageId"]).to eq("some-id")
     expect(data["Records"][0]["Sns"]["Timestamp"]).to eq("some-timestamp")
-    expect(data["Records"][0]["Sns"]["Message"]).to eq("some-body")
+    expect(JSON.parse data["Records"][0]["Sns"]["Message"]).to eq(message)
+  end
+
+  it "should generate an SNS event (string body)" do
+    message = { "this_is" => "the message" }
+    data = LambdaRunner::Events.sns_event("some-arn", "some-id", "some-timestamp", JSON.generate(message))
+    expect(data["Records"][0]["Sns"]["TopicArn"]).to eq("some-arn")
+    expect(data["Records"][0]["Sns"]["MessageId"]).to eq("some-id")
+    expect(data["Records"][0]["Sns"]["Timestamp"]).to eq("some-timestamp")
+    expect(JSON.parse data["Records"][0]["Sns"]["Message"]).to eq(message)
   end
 
 end


### PR DESCRIPTION
…essage

so that code like this still works:

   s3_event = LambdaRunner::Events.s3_event(@bucket_in_event, @object_name, 'file')
   sns_event = LambdaRunner::Events.sns_event('someTopicArn', 'someMessageId', 'someTimestamp', s3_event)
    UNDERTEST.process_event(sns_event)
