### PR TITLE
Added ability to create DynamoDB events

### DIFF
--- a/lib/lambda_runner.rb
+++ b/lib/lambda_runner.rb
@@ -99,6 +99,28 @@ module LambdaRunner
       event
     end
 
+    def self.dynamodb_event(key, new_image = nil, old_image = nil)
+      event = load_json('sample_dynamodb_event.json')
+      get_dynamodb_record(event['Records'][0], key, new_image, old_image)
+      event
+    end
+
+    private_class_method def self.get_dynamodb_record(record, key, new_image, old_image)
+      if new_image && old_image
+        record['dynamodb']['NewImage'] = new_image['NewImage']
+        record['dynamodb']['OldImage'] = old_image['OldImage']
+        record['eventName'] = 'MODIFY'
+      elsif new_image
+        record['dynamodb']['NewImage'] = new_image['NewImage']
+        record['eventName'] = 'INSERT'
+      else
+        record['dynamodb']['OldImage'] = old_image['OldImage']
+        record['eventName'] = 'REMOVE'
+      end
+      record['dynamodb']['Keys'] = key
+      record
+    end
+
     private
 
     def self.load_json(name)

--- a/samples/sample_dynamodb_event.json
+++ b/samples/sample_dynamodb_event.json
@@ -1,0 +1,19 @@
+{
+  "Records": [
+    {
+      "eventID": "e837fca4eb43e83b3ffb681d1daa701d",
+      "eventName": "INSERT",
+      "eventVersion": "1.0",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "eu-west-1",
+      "dynamodb": {
+        "Keys": {
+        },
+       "SequenceNumber": "0",
+       "SizeBytes": 149,
+       "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:123456789:table/dynamodb-table/stream/2015-09-30T16:34:32.317"
+    }
+  ]
+}

--- a/spec/lambda-runner_spec.rb
+++ b/spec/lambda-runner_spec.rb
@@ -28,4 +28,42 @@ describe LambdaRunner::Events do
     expect(JSON.parse data["Records"][0]["Sns"]["Message"]).to eq(message)
   end
 
+  it "should generate an DynamoDB event for insert (data body)" do
+    new_image = { "NewImage" => { "id" => { "S" => "1234567ABC" }, "message" => { "S" => "updated message" } } }
+    key = { "id" => { "S" => "1234567ABC" } }
+
+    data = LambdaRunner::Events.dynamodb_event(key, new_image)
+
+    expect(data["Records"][0]["dynamodb"]["NewImage"]).to eq(new_image["NewImage"])
+    expect(data["Records"][0]["dynamodb"]["Keys"]).to eq(key)
+    expect(data["Records"][0]["eventName"]).to eq("INSERT")
+    expect(data["Records"][0]["dynamodb"]["SequenceNumber"]).to eq("0")
+  end
+
+  it "should generate an DynamoDB event for remove (data body)" do
+    old_image = { "OldImage" => { "id" => { "S" => "1234567ABC" }, "message" => { "S" => "message" } } }
+    key = { "id" => { "S" => "1234567ABC" } }
+
+    data = LambdaRunner::Events.dynamodb_event(key, nil, old_image)
+
+    expect(data["Records"][0]["dynamodb"]["OldImage"]).to eq(old_image["OldImage"])
+    expect(data["Records"][0]["dynamodb"]["Keys"]).to eq(key)
+    expect(data["Records"][0]["eventName"]).to eq("REMOVE")
+    expect(data["Records"][0]["dynamodb"]["SequenceNumber"]).to eq("0")
+  end
+
+  it "should generate an DynamoDB event for modify (data body)" do
+    old_image = { "OldImage" => { "id" => { "S" => "1234567ABC" }, "message" => { "S" => "message" } } }
+    new_image = { "NewImage" => { "id" => { "S" => "1234567ABC" }, "message" => { "S" => "updated message" } } }
+    key = { "id" => { "S" => "1234567ABC" } }
+
+    data = LambdaRunner::Events.dynamodb_event(key, new_image, old_image)
+
+    expect(data["Records"][0]["dynamodb"]["OldImage"]).to eq(old_image["OldImage"])
+    expect(data["Records"][0]["dynamodb"]["NewImage"]).to eq(new_image["NewImage"])
+    expect(data["Records"][0]["dynamodb"]["Keys"]).to eq(key)
+    expect(data["Records"][0]["eventName"]).to eq("MODIFY")
+    expect(data["Records"][0]["dynamodb"]["SequenceNumber"]).to eq("0")
+  end
+
 end


### PR DESCRIPTION
I've added some code to create DynamoDb stream events similar to the SNS and S3 events. It's simple right now but there's a few things we can add to enchace it.

1. Instead of taking a default complex structure, we can just take a hash of the old and new image. Then dynamically select the type. For example, instead of:
```ruby
new_image = { "NewImage" => { "id" => { "S" => "1234567ABC" }, "message" => { "S" => "updated message" } } }
key = { "id" => { "S" => "1234567ABC" } }
event = LambdaRunner::Events.dynamodb_event(key, new_image)
```
 we can have:
```ruby
new_image = { "NewImage" => { "id" => "1234567ABC" , "message" => "updated message" } } 
key = { "id" => "1234567ABC" }
event = LambdaRunner::Events.dynamodb_event(key, new_image)
```
And dynamically select the type of the data at runtime. 

2. Assert `NewImage` and `OldImage` exists in the incoming parameters.
3. Add the ability to take in a list of new images/old images and return a event with multiple records with it.

Open to disscussions regarding this pull request. Also, would it be possible to bump up the version of the gem and also the date? If you check here: https://rubygems.org/gems/aws-lambda-runner/versions/1.1.1 the date hasn't been updated in a very long time.