### PR TITLE
NodeJS 4.3

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -9,18 +9,18 @@
   "author": "",
   "license": " ",
   "devDependencies": {
-    "assert": "^1.3.0",
-    "jshint": "^2.5.11",
-    "mocha": "^2.1.0",
-    "mocha-jshint": "0.0.9",
-    "mock-res": "^0.2.1",
-    "should": "^4.6.0"
+    "assert": "^1.4.1",
+    "jshint": "^2.9.4",
+    "mocha": "^3.3.0",
+    "mocha-jshint": "^2.3.1",
+    "mock-res": "^0.4.1",
+    "should": "^11.2.1"
   },
   "dependencies": {
-    "aws-sdk": "^2.1.34",
-    "istanbul": "^0.3.6",
+    "aws-sdk": "*",
+    "istanbul": "^0.4.5",
     "merge": "^1.2.0",
-    "mock-req": "^0.1.0",
+    "mock-req": "^0.2.0",
     "stdio": "^0.2.7"
   }
 }

--- a/js/request.js
+++ b/js/request.js
@@ -53,9 +53,6 @@ var makeContextObject = function (timeout, overrides) {
     return approximateEndTime - (new Date().getTime());
   };
 
-  context.fail = function(err) { context.done(err, null); };
-  context.succeed = function(data) { context.done(null, data); };
-
   return context;
 };
 
@@ -75,14 +72,7 @@ var startJob = function (job, requestObject, handler, opts) {
   };
 
   try {
-    if (parseInt(process.versions.node.split('.')[0], 10) >= 4) {
-      delete context.fail;
-      delete context.succeed;
-      handler(event, context, context.done);
-    }
-    else {
-      handler(event, context);
-    }
+    handler(event, context, context.done);
   } catch (e) {
     console.log("Handler crashed", e);
     job.doError(e);

--- a/js/request.js
+++ b/js/request.js
@@ -75,7 +75,7 @@ var startJob = function (job, requestObject, handler, opts) {
   };
 
   try {
-    if (parseInt(process.versions['node'].split('.')[0], 10) >= 4) {
+    if (parseInt(process.versions.node.split('.')[0], 10) >= 4) {
       delete context.fail;
       delete context.succeed;
       handler(event, context, context.done);

--- a/js/request.js
+++ b/js/request.js
@@ -75,7 +75,14 @@ var startJob = function (job, requestObject, handler, opts) {
   };
 
   try {
-    handler(event, context);
+    if (parseInt(process.versions['node'].split('.')[0], 10) >= 4) {
+      delete context.fail;
+      delete context.succeed;
+      handler(event, context, context.done);
+    }
+    else {
+      handler(event, context);
+    }
   } catch (e) {
     console.log("Handler crashed", e);
     job.doError(e);

--- a/spec/lambdarunner_runner_spec.rb
+++ b/spec/lambdarunner_runner_spec.rb
@@ -5,7 +5,7 @@ describe LambdaRunner::Runner do
 
   before(:all) do
     test_js = File.expand_path("test.js", File.dirname(__FILE__))
-    @under_test = LambdaRunner::Runner.new(test_js, "node_0_10_42_handler")
+    @under_test = LambdaRunner::Runner.new(test_js, "node_4_3_handler")
     @under_test.start
   end
 
@@ -13,12 +13,12 @@ describe LambdaRunner::Runner do
     @under_test.stop
   end
 
-  it "should emulate AWS Lambda (node.js v0.10.42) - success" do
+  it "should emulate AWS Lambda (node.js v4.3) - success" do
     r = @under_test.process_event({ succeed: { delay: 50, result: "ohai" } })
     expect(r).to eq("ohai")
   end
 
-  it "should emulate AWS Lambda (node.js v0.10.42) - failure" do
+  it "should emulate AWS Lambda (node.js v4.3) - failure" do
     expect {
       @under_test.process_event({ fail: { delay: 50, err: "oh noes" } })
     }.to raise_error("oh noes")

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,11 +1,11 @@
-module.exports.node_0_10_42_handler = function (event, context) {
+module.exports.node_4_3_handler = function (event, context, callback) {
   console.log("test handler received event =", JSON.stringify(event));
 
   if (event.succeed) {
     var delay = event.succeed.delay || 0;
     var result = event.succeed.result || null;
     setTimeout(function () {
-      context.done(null, result);
+      callback(null, result);
     }, delay);
   }
 
@@ -13,7 +13,7 @@ module.exports.node_0_10_42_handler = function (event, context) {
     var delay = event.fail.delay || 0;
     var err = event.fail.err || true;
     setTimeout(function () {
-      context.done(err);
+      callback(err);
     }, delay);
   }
 };


### PR DESCRIPTION
AWS have deprecated and removed support for lambdas written in NodeJS 0.10.  They have also changed the signature of the Lambda handler function from `handler(event, context)` to `handler(event, context, callback)`.  The `callback` argument replaces the `context.fail`, `context.succeed` and `context.done` methods (although if you log the `context` object in AWS you will see the `context.done` method still exists and is probably called by `callback` seeing as the behaviour is the same).

This PR adds support for lambdas written in NodeJS 4.3+ (including 6.10) without removing the existing support for lambdas written in NodeJS 0.10.  The tests have been updated to work with NodeJS 4.3 but several packages have had to be upgraded in the process and as a result the tests no longer work with NodeJS 0.10.