### PR TITLE
Switch to the 4.3.x -style invocation (callback as last argument)

### DIFF
--- a/js/request.js
+++ b/js/request.js
@@ -75,7 +75,7 @@ var startJob = function (job, requestObject, handler, opts) {
   };
 
   try {
-    handler(event, context);
+    handler(event, context, context.done);
   } catch (e) {
     console.log("Handler crashed", e);
     job.doError(e);

--- a/spec/lambdarunner_runner_spec.rb
+++ b/spec/lambdarunner_runner_spec.rb
@@ -5,7 +5,7 @@ describe LambdaRunner::Runner do
 
   before(:all) do
     test_js = File.expand_path("test.js", File.dirname(__FILE__))
-    @under_test = LambdaRunner::Runner.new(test_js, "node_0_10_42_handler")
+    @under_test = LambdaRunner::Runner.new(test_js, "handler_method")
     @under_test.start
   end
 

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,11 +1,11 @@
-module.exports.node_0_10_42_handler = function (event, context) {
+module.exports.handler_method = function (event, context, callback) {
   console.log("test handler received event =", JSON.stringify(event));
 
   if (event.succeed) {
     var delay = event.succeed.delay || 0;
     var result = event.succeed.result || null;
     setTimeout(function () {
-      context.done(null, result);
+      callback(null, result);
     }, delay);
   }
 
@@ -13,7 +13,7 @@ module.exports.node_0_10_42_handler = function (event, context) {
     var delay = event.fail.delay || 0;
     var err = event.fail.err || true;
     setTimeout(function () {
-      context.done(err);
+      callback(err);
     }, delay);
   }
 };


### PR DESCRIPTION
No point providing dual support for 0.10.42 as well since that's going to disappear from AWS imminently.
