### PR TITLE
Added optional port parameter to ruby LambdaRunner

### DIFF
--- a/lib/lambda_runner.rb
+++ b/lib/lambda_runner.rb
@@ -8,10 +8,10 @@ require 'fileutils'
 module LambdaRunner
   # abstract for running the program
   class Runner
-    def initialize(module_path, name)
+    def initialize(module_path, name, port = 8897)
       @module_path = module_path
       @name = name
-      @port = 8897
+      @port = port
     end
 
     def install_deps


### PR DESCRIPTION
I had port clashes issues on jenkins when running multiple build in parallel.
Would be nice to permit change the hard coded 8897 port in the Ruby LambdaRunner in the same way of the `--port` parameter in the Node.js LambdaRunner